### PR TITLE
add basic Array/NativeArray implementation

### DIFF
--- a/src/generators/genphp7.ml
+++ b/src/generators/genphp7.ml
@@ -923,8 +923,8 @@ class virtual type_builder ctx wrapper =
 			Writes TArrayDecl to output buffer
 		*)
 		method private write_expr_array_decl exprs =
-		  self#write ((self#use hxarray_type_path) ^ "::wrap(");
-		  (match exprs with
+			self#write ((self#use hxarray_type_path) ^ "::wrap(");
+			(match exprs with
 				| [] -> self#write "[]"
 				| [expr] ->
 					self#write "[";

--- a/src/generators/genphp7.ml
+++ b/src/generators/genphp7.ml
@@ -30,6 +30,10 @@ let hxenum_type_path = (["php7"; "_Boot"], "HxEnum")
 	Type path of the implementation class for `Class<Dynamic>`
 *)
 let hxclass_type_path = (["php7"; "_Boot"], "HxClass")
+(**
+	Type path of the implementation class for `Array<T>`
+*)
+let hxarray_type_path = ([], "HxArray")
 
 (**
 	Resolve real type (bypass abstracts and typedefs)
@@ -837,7 +841,8 @@ class virtual type_builder ctx wrapper =
 			Writes TArrayDecl to output buffer
 		*)
 		method private write_expr_array_decl exprs =
-			match exprs with
+		  self#write ((self#use hxarray_type_path) ^ "::wrap(");
+		  (match exprs with
 				| [] -> self#write "[]"
 				| [expr] ->
 					self#write "[";
@@ -850,6 +855,8 @@ class virtual type_builder ctx wrapper =
 					self#indent_less;
 					self#write_indentation;
 					self#write "]"
+				);
+			self#write ")"
 		(**
 			Writes TArray to output buffer
 		*)
@@ -857,7 +864,7 @@ class virtual type_builder ctx wrapper =
 			self#write_expr target;
 			self#write "[";
 			self#write_expr index;
-			self#write "]"
+			self#write "]";
 		(**
 			Writes TVar to output buffer
 		*)

--- a/std/php7/Boot.hx
+++ b/std/php7/Boot.hx
@@ -249,8 +249,8 @@ private class HxEnum {
 		return instance;
 	}
 
-	public function new(constructor:String, arguments:NativeArray = null) : Void {
+	public function new(constructor:String, arguments:NativeArrayI<Dynamic> = null) : Void {
 		this.constructor = constructor;
-		this.arguments = (arguments == null ? [] : arguments.toHaxeArray());
+		this.arguments = (arguments == null ? [] : arguments);
 	}
 }

--- a/std/php7/Boot.hx
+++ b/std/php7/Boot.hx
@@ -253,7 +253,7 @@ private class HxEnum {
 		return instance;
 	}
 
-	public function new(constructor:String, arguments:NativeArrayI<Dynamic> = null) : Void {
+	public function new(constructor:String, arguments:NativeIndexedArray<Dynamic> = null) : Void {
 		this.constructor = constructor;
 		this.arguments = (arguments == null ? [] : arguments);
 	}

--- a/std/php7/Global.hx
+++ b/std/php7/Global.hx
@@ -1,6 +1,6 @@
 package php7;
 
-
+import haxe.extern.Rest;
 
 /**
     This class contains externs for native PHP functions defined in global namespace.
@@ -82,4 +82,84 @@ extern class Global {
     **/
     @:overload(function(original:String,alias:String):Bool {})
     static function class_alias( original:String, alias:String, autoload:Bool ) : Bool ;
+
+
+    /**
+        @see http://php.net/manual/en/function.count.php
+    **/
+    @:overload(function(array:NativeArray):Int {})
+    static function count( array:NativeArray, mode:Int ) : Int ;
+
+    /**
+        @see http://php.net/manual/en/function.array-filter.php
+    **/
+    @:overload(function(array:NativeArray):NativeArray {})
+    @:overload(function(array:NativeArray,callback:Dynamic->Bool):NativeArray {})
+    static function array_filter( array:NativeArray, callback:Dynamic->Bool, flag:Int ) : NativeArray ;
+
+    /**
+        @see http://php.net/manual/en/function.implode.php
+    **/
+    static function implode( glue:String = "", array:NativeArray ) : String ;
+
+    /**
+        @see http://php.net/manual/en/function.array-map.php
+    **/
+    static function array_map( callback:Dynamic->Dynamic, array:Rest<NativeArray> ) : NativeArray ;
+
+    /**
+        @see http://php.net/manual/en/function.array-merge.php
+    **/
+    static function array_merge( array:Rest<NativeArray> ) : NativeArray ;
+
+    /**
+        @see http://php.net/manual/en/function.array-pop.php
+    **/
+    static function array_pop( array:NativeArray ) : Dynamic;
+
+    /**
+        @see http://php.net/manual/en/function.array-push.php
+    **/
+    static function array_push( array:NativeArray, value:Rest<Dynamic> ) : Int ;
+
+    /**
+        @see http://php.net/manual/en/function.array-reverse.php
+    **/
+    @:overload(function(array:NativeArray):NativeArray {})
+    static function array_reverse( array:NativeArray, preserve_keys:Bool ) : NativeArray ;
+
+    /**
+        @see http://php.net/manual/en/function.array-search.php
+    **/
+    @:overload(function(needle:Dynamic,haystack:NativeArray):Dynamic {})
+    static function array_search( needle:Dynamic, haystack:NativeArray, strict:Bool ) : Dynamic ;
+
+    /**
+        @see http://php.net/manual/en/function.array-shift.php
+    **/
+    static function array_shift( array:NativeArray ) : Dynamic ;
+
+    /**
+        @see http://php.net/manual/en/function.array-slice.php
+    **/
+    @:overload(function(array:NativeArray,offset:Int):NativeArray {})
+    @:overload(function(array:NativeArray,offset:Int,length:Int):NativeArray {})
+    static function array_slice( array:NativeArray, offset:Int, length:Int, preserve_keys:Bool ) : NativeArray ;
+
+    /**
+        @see http://php.net/manual/en/function.array-splice.php
+    **/
+    @:overload(function(array:NativeArray,offset:Int):NativeArray {})
+    @:overload(function(array:NativeArray,offset:Int,length:Int):NativeArray {})
+    static function array_splice( array:NativeArray, offset:Int, lenght:Int, replacement:Dynamic ) : NativeArray ;
+
+    /**
+        @see http://php.net/manual/en/function.array-unshift.php
+    **/
+    static function array_unshift( arr:NativeArray, value:Rest<Dynamic> ) : Int ;
+
+    /**
+        @see http://php.net/manual/en/function.usort.php
+    **/
+    static function usort( array:NativeArray, value_compare_func:Dynamic->Dynamic->Int ) : Bool ;
 }

--- a/std/php7/Lib.hx
+++ b/std/php7/Lib.hx
@@ -85,7 +85,7 @@ class Lib {
 		return untyped __call__("fpassthru", __call__("fopen", file,  "r"));
 	}
 
-	/*public static function toPhpArray(a : Array<Dynamic>) : NativeArray {
+	public static function toPhpArray(a : Array<Dynamic>) : NativeArray {
 		throw "Not implemented";
 	}
 
@@ -107,7 +107,7 @@ class Lib {
 
 	public static function associativeArrayOfObject(ob : Dynamic) : NativeArray {
 		throw "Not implemented";
-	}*/
+	}
 
 	/**
 	 * See the documentation for the equivalent PHP function for details on usage:

--- a/std/php7/Lib.hx
+++ b/std/php7/Lib.hx
@@ -85,7 +85,7 @@ class Lib {
 		return untyped __call__("fpassthru", __call__("fopen", file,  "r"));
 	}
 
-	public static function toPhpArray(a : Array<Dynamic>) : NativeArray {
+	/*public static function toPhpArray(a : Array<Dynamic>) : NativeArray {
 		throw "Not implemented";
 	}
 
@@ -107,7 +107,7 @@ class Lib {
 
 	public static function associativeArrayOfObject(ob : Dynamic) : NativeArray {
 		throw "Not implemented";
-	}
+	}*/
 
 	/**
 	 * See the documentation for the equivalent PHP function for details on usage:

--- a/std/php7/NativeArray.hx
+++ b/std/php7/NativeArray.hx
@@ -21,6 +21,117 @@
  */
 package php7;
 
-extern class NativeArray implements ArrayAccess<Dynamic> {
+import haxe.extern.Rest;
+import haxe.extern.EitherType;
 
+//@:coreType
+abstract NativeArray<T>(Dynamic) {
+  public inline function count():Int
+    return Arr.count(this);
+
+  public inline function filter(cb:T->Bool):NativeArray<T>
+    return Arr.filter(this, cb);
+
+  public inline function implode(glue:String):String
+    return Arr.implode(glue, this);
+
+  public inline function map<S>(cb:T->S):NativeArray<S>
+    return Arr.map(cb, this);
+
+  public inline function merge(arr:NativeArray<T>):NativeArray<T>
+    return Arr.merge(this, arr);
+
+  public inline function pop():T
+    return Arr.pop(this);
+
+  public inline function push(val:T):Int
+    return Arr.push(this, val);
+
+  public inline function reverse():NativeArray<T>
+    return Arr.reverse(this);
+
+  public inline function shift():T
+    return Arr.shift(this);
+
+  public inline function slice(offset:Int, ?len:Int):NativeArray<T>
+    return Arr.slice(this, offset, len);
+
+  public inline function splice(offset:Int, len:Int, ?repl:T):NativeArray<T>
+    return Arr.splice(this, offset, len, repl);
+
+  public inline function unshift(val:T):Int
+    return Arr.unshift(this, val);
+
+  public inline function usort(func:T->T->Int):Bool
+    return Arr.usort(this, func);
+
+  @:to inline function toIndexedArray():NativeArrayI<T>
+    return cast this;
+}
+
+@:forward
+abstract NativeArrayI<T>(NativeArray<T>) {
+  public inline function new()
+    this = Arr.create();
+
+  @:to inline function toNativeArray():NativeArray<T>
+    return this;
+
+  @:to inline function toHaxeArray():Array<T>
+    return @:privateAccess Array.wrap(this);
+
+  @:from static inline function fromHaxeArray<T>(a:Array<T>):NativeArrayI<T>
+    return @:privateAccess a.arr;
+
+  @:arrayAccess inline function get(idx:Int):T
+    return untyped this[idx];
+
+  @:arrayAccess inline function set(idx:Int, val:T)
+    untyped this[idx] = val;
+}
+
+@:phpGlobal
+private extern class Arr {
+  @:native("array")
+  static function create<T>():NativeArray<T>;
+
+  @:native("\\count")
+  static function count<T>(arr:NativeArray<T>, ?mode:Int = 0):Int;
+
+  @:native("\\array_filter")
+  static function filter<T>(arr:NativeArray<T>, cb:T->Bool, ?flag:Int = 0):NativeArray<T>;
+
+  @:native("\\implode")
+  static function implode<T>(glue:String = "", arr:NativeArray<T>):String;
+
+  @:native("\\array_map")
+  static function map<T,S>(cb:T->S, arr:NativeArray<T>):NativeArray<S>;
+
+  @:native("\\array_merge")
+  static function merge<T>(arr1:NativeArray<T>, arrN:Rest<NativeArray<T>>):NativeArray<T>;
+
+  @:native("\\array_pop")
+  static function pop<T>(arr:NativeArray<T>):T;
+
+  @:native("\\array_push")
+  static function push<T>(arr:NativeArray<T>, val:T):Int;
+
+  @:native("\\array_reverse")
+  static function reverse<T>(arr:NativeArray<T>, ?pres:Bool = false):NativeArray<T>;
+
+  @:native("\\array_shift")
+  static function shift<T>(arr:NativeArray<T>):T;
+
+  @:native("\\array_slice")
+  static function slice<T>(arr:NativeArray<T>, offset:Int, ?len:Int, ?pres:Bool=false):NativeArray<T>;
+
+  @:native("\\array_splice")
+  static function splice<T>(arr:NativeArray<T>, offset:Int, ?len:Int = 0,
+    ?repl:EitherType<T,NativeArray<T>>):NativeArray<T>;
+
+  @:native("\\array_unshift")
+  static function unshift<T>(arr:NativeArray<T>, val:Rest<T>):Int;
+
+  @:native("\\usort")
+  static function usort<T>(arr:NativeArray<T>, func:T->T->Int):Bool;
 }

--- a/std/php7/NativeArray.hx
+++ b/std/php7/NativeArray.hx
@@ -25,113 +25,125 @@ import haxe.extern.Rest;
 import haxe.extern.EitherType;
 
 //@:coreType
-abstract NativeArray<T>(Dynamic) {
+@:arrayAccess
+abstract NativeArray(Dynamic) {
+
+  @:arrayAccess
+  inline function get<T>(key:EitherType<Int,String>):T
+    return this[key];
+
+  @:arrayAccess
+  inline function set<T>(key:EitherType<Int,String>, val:T)
+    this[key] = val;
+
   public inline function count():Int
     return Arr.count(this);
 
-  public inline function filter(cb:T->Bool):NativeArray<T>
+  public inline function filter<T>(cb:T->Bool):NativeArray
     return Arr.filter(this, cb);
 
   public inline function implode(glue:String):String
     return Arr.implode(glue, this);
 
-  public inline function map<S>(cb:T->S):NativeArray<S>
+  public inline function map<T,S>(cb:T->S):NativeArray
     return Arr.map(cb, this);
 
-  public inline function merge(arr:NativeArray<T>):NativeArray<T>
+  public inline function merge(arr:NativeArray):NativeArray
     return Arr.merge(this, arr);
 
-  public inline function pop():T
+  public inline function pop<T>():T
     return Arr.pop(this);
 
-  public inline function push(val:T):Int
+  public inline function push<T>(val:T):Int
     return Arr.push(this, val);
 
-  public inline function reverse():NativeArray<T>
+  public inline function reverse():NativeArray
     return Arr.reverse(this);
 
-  public inline function shift():T
+  public inline function shift<T>():T
     return Arr.shift(this);
 
-  public inline function slice(offset:Int, ?len:Int):NativeArray<T>
+  public inline function slice(offset:Int, ?len:Int):NativeArray
     return Arr.slice(this, offset, len);
 
-  public inline function splice(offset:Int, len:Int, ?repl:T):NativeArray<T>
+  public inline function splice<T>(offset:Int, len:Int, ?repl:T):NativeArray
     return Arr.splice(this, offset, len, repl);
 
-  public inline function unshift(val:T):Int
+  public inline function unshift<T>(val:T):Int
     return Arr.unshift(this, val);
 
-  public inline function usort(func:T->T->Int):Bool
+  public inline function usort<T>(func:T->T->Int):Bool
     return Arr.usort(this, func);
 
-  @:to inline function toIndexedArray():NativeArrayI<T>
-    return cast this;
 }
 
+
 @:forward
-abstract NativeArrayI<T>(NativeArray<T>) {
+abstract NativeArrayI<T>(NativeArray) from NativeArray to NativeArray {
+
   public inline function new()
-    this = Arr.create();
+    this = untyped __php__("[]");
 
-  @:to inline function toNativeArray():NativeArray<T>
-    return this;
+  @:arrayAccess
+  inline function get(idx:Int):T
+    return this[idx];
 
-  @:to inline function toHaxeArray():Array<T>
+  @:arrayAccess
+  inline function set(idx:Int, val:T)
+    this[idx] = val;
+
+  @:to
+  inline function toHaxeArray():Array<T>
     return @:privateAccess Array.wrap(this);
 
-  @:from static inline function fromHaxeArray<T>(a:Array<T>):NativeArrayI<T>
+  @:from
+  static inline function fromHaxeArray<T>(a:Array<T>):NativeArrayI<T>
     return @:privateAccess a.arr;
 
-  @:arrayAccess inline function get(idx:Int):T
-    return untyped this[idx];
-
-  @:arrayAccess inline function set(idx:Int, val:T)
-    untyped this[idx] = val;
 }
 
 @:phpGlobal
 private extern class Arr {
   @:native("array")
-  static function create<T>():NativeArray<T>;
+  static function create():NativeArray;
 
   @:native("\\count")
-  static function count<T>(arr:NativeArray<T>, ?mode:Int = 0):Int;
+  static function count(arr:NativeArray, ?mode:Int = 0):Int;
 
   @:native("\\array_filter")
-  static function filter<T>(arr:NativeArray<T>, cb:T->Bool, ?flag:Int = 0):NativeArray<T>;
+  static function filter<T>(arr:NativeArray, cb:T->Bool, ?flag:Int = 0):NativeArray;
 
   @:native("\\implode")
-  static function implode<T>(glue:String = "", arr:NativeArray<T>):String;
+  static function implode(glue:String = "", arr:NativeArray):String;
 
   @:native("\\array_map")
-  static function map<T,S>(cb:T->S, arr:NativeArray<T>):NativeArray<S>;
+  static function map<T,S>(cb:T->S, arr:NativeArray):NativeArray;
 
   @:native("\\array_merge")
-  static function merge<T>(arr1:NativeArray<T>, arrN:Rest<NativeArray<T>>):NativeArray<T>;
+  static function merge(arr1:NativeArray, arrN:Rest<NativeArray>):NativeArray;
 
   @:native("\\array_pop")
-  static function pop<T>(arr:NativeArray<T>):T;
+  static function pop<T>(arr:NativeArray):T;
 
   @:native("\\array_push")
-  static function push<T>(arr:NativeArray<T>, val:T):Int;
+  static function push<T>(arr:NativeArray, val:T):Int;
 
   @:native("\\array_reverse")
-  static function reverse<T>(arr:NativeArray<T>, ?pres:Bool = false):NativeArray<T>;
+  static function reverse(arr:NativeArray, ?pres:Bool = false):NativeArray;
 
   @:native("\\array_shift")
-  static function shift<T>(arr:NativeArray<T>):T;
+  static function shift<T>(arr:NativeArray):T;
 
   @:native("\\array_slice")
-  static function slice<T>(arr:NativeArray<T>, offset:Int, ?len:Int, ?pres:Bool=false):NativeArray<T>;
+  static function slice<T>(arr:NativeArray, offset:Int, ?len:Int, ?pres:Bool=false):NativeArray;
 
   @:native("\\array_splice")
-  static function splice<T>(arr:NativeArray<T>, offset:Int, ?len:Int = 0,
-    ?repl:EitherType<T,NativeArray<T>>):NativeArray<T>;
+  static function splice<T>(arr:NativeArray, offset:Int, ?len:Int = 0,
+    ?repl:EitherType<T,NativeArray>):NativeArray;
 
   @:native("\\array_unshift")
-  static function unshift<T>(arr:NativeArray<T>, val:Rest<T>):Int;
+  static function unshift<T>(arr:NativeArray, val:Rest<T>):Int;
 
   @:native("\\usort")
-  static function usort<T>(arr:NativeArray<T>, func:T->T->Int):Bool;
+  static function usort<T>(arr:NativeArray, func:T->T->Int):Bool;
 }

--- a/std/php7/NativeArray.hx
+++ b/std/php7/NativeArray.hx
@@ -24,17 +24,17 @@ package php7;
 import haxe.extern.Rest;
 import haxe.extern.EitherType;
 
-//@:coreType
-@:arrayAccess
-abstract NativeArray(Dynamic) {
+@:coreType
+//@:arrayAccess
+abstract NativeArray {
 
-  @:arrayAccess
+  /*@:arrayAccess
   inline function get<T>(key:EitherType<Int,String>):T
     return this[key];
 
   @:arrayAccess
   inline function set<T>(key:EitherType<Int,String>, val:T)
-    this[key] = val;
+    this[key] = val;*/
 
   public inline function count():Int
     return Arr.count(this);
@@ -80,17 +80,16 @@ abstract NativeArray(Dynamic) {
 
 @:forward
 abstract NativeArrayI<T>(NativeArray) from NativeArray to NativeArray {
-
   public inline function new()
     this = untyped __php__("[]");
 
   @:arrayAccess
   inline function get(idx:Int):T
-    return this[idx];
+    return untyped this[idx];
 
   @:arrayAccess
   inline function set(idx:Int, val:T)
-    this[idx] = val;
+    untyped this[idx] = val;
 
   @:to
   inline function toHaxeArray():Array<T>
@@ -99,14 +98,10 @@ abstract NativeArrayI<T>(NativeArray) from NativeArray to NativeArray {
   @:from
   static inline function fromHaxeArray<T>(a:Array<T>):NativeArrayI<T>
     return @:privateAccess a.arr;
-
 }
 
 @:phpGlobal
 private extern class Arr {
-  @:native("array")
-  static function create():NativeArray;
-
   @:native("\\count")
   static function count(arr:NativeArray, ?mode:Int = 0):Int;
 

--- a/std/php7/NativeAssocArray.hx
+++ b/std/php7/NativeAssocArray.hx
@@ -21,37 +21,17 @@
  */
 package php7;
 
-import haxe.extern.EitherType;
-
-//@:coreType //doesn't seem to work atm
-//@:arrayAccess
-@:runtimeValue
-abstract NativeArray(Dynamic) {
+@:forward
+abstract NativeAssocArray<T>(NativeArray) from NativeArray to NativeArray {
 	public inline function new()
 		this = untyped __php__("[]");
 
 	@:arrayAccess
-	inline function get(key:Scalar):Dynamic
+	inline function get(key:String):T
 		return this[key];
 
 	@:arrayAccess
-	inline function set(key:Scalar, val:Dynamic)
+	inline function set(key:String, val:T)
 		this[key] = val;
 
-	public inline function count():Int
-		return Global.count(this);
-
-	public inline function implode(glue:String):String
-		return Global.implode(glue, this);
-
-	public inline function merge(arr:NativeArray):NativeArray
-		return Global.array_merge(this, arr);
-
-	public inline function reverse():NativeArray
-		return Global.array_reverse(this);
-
-	public inline function slice(offset:Int, len:Int):NativeArray
-		return Global.array_slice(this, offset, len);
 }
-
-private typedef Scalar = EitherType<Int,EitherType<String,EitherType<Float,Bool>>>;

--- a/std/php7/NativeIndexedArray.hx
+++ b/std/php7/NativeIndexedArray.hx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C)2005-2016 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package php7;
+
+import haxe.extern.EitherType;
+
+@:forward
+abstract NativeIndexedArray<T>(NativeArray) from NativeArray to NativeArray {
+	public inline function new()
+		this = untyped __php__("[]");
+
+	@:arrayAccess
+	inline function get(idx:Int):T
+		return this[idx];
+
+	@:arrayAccess
+	inline function set(idx:Int, val:T)
+		this[idx] = val;
+
+	@:to
+	inline function toHaxeArray():Array<T>
+		return @:privateAccess Array.wrap(this);
+
+	@:from
+	static inline function fromHaxeArray<T>(a:Array<T>):NativeIndexedArray<T>
+		return @:privateAccess a.arr;
+
+	public inline function filter(cb:T->Bool):NativeIndexedArray<T>
+		return Global.array_filter(this, cb);
+
+	public inline function map<S>(cb:T->S):NativeIndexedArray<S>
+		return Global.array_map(cb, this);
+
+	public inline function pop():T
+		return Global.array_pop(this);
+
+	public inline function push(val:T):Int
+		return Global.array_push(this, val);
+
+	public inline function search(needle:T):KeyOrFalse
+		return Global.array_search(needle, this, true);
+
+	public inline function shift():T
+		return Global.array_shift(this);
+
+	public inline function splice(offset:Int, len:Int, ?repl:T):NativeIndexedArray<T>
+		return Global.array_splice(this, offset, len, repl);
+
+	public inline function unshift(val:T):Int
+		return Global.array_unshift(this, val);
+
+	public inline function usort(func:T->T->Int):Bool
+		return Global.usort(this, func);
+}
+
+private typedef KeyOrFalse = EitherType<EitherType<String,Int>,Bool>;

--- a/std/php7/_std/Array.hx
+++ b/std/php7/_std/Array.hx
@@ -19,16 +19,16 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-import php7.NativeArray;
+import php7.NativeIndexedArray;
 
 @:coreApi
 @:native("HxArray")
 class Array<T> {
 	public var length(default, null):Int;
-	var arr:NativeArrayI<T>;
+	var arr:NativeIndexedArray<T>;
 
 	public function new() {
-		arr = new NativeArrayI<T>();
+		arr = new NativeIndexedArray<T>();
 		length = 0;
 	}
 
@@ -45,13 +45,30 @@ class Array<T> {
 	}
 
 	public function indexOf(x:T, ?fromIndex:Int):Int {
-		if (fromIndex == null) fromIndex = 0;
+		/*if (fromIndex == null) fromIndex = 0;
+		if (fromIndex < 0) fromIndex += length - 1;
+		if (fromIndex < 0) fromIndex = 0;
 		while (fromIndex < length) {
 			if (arr[fromIndex] == x)
 				return fromIndex;
 			fromIndex++;
 		}
-		return -1;
+		return -1;*/
+		// maybe better?
+		var idx = arr.search(x);
+		if (idx == false)
+			return -1;
+		if (fromIndex != null) {
+			if (fromIndex >= length)
+				return -1;
+			if (fromIndex < 0) fromIndex += length - 1;
+			if (fromIndex > 0) {
+				idx -= fromIndex;
+				if ((idx:Int) < 0)
+					return -1;
+			}
+		}
+		return idx;
 	}
 
 	public function insert(pos:Int, x:T):Void {
@@ -60,7 +77,7 @@ class Array<T> {
 	}
 
 	public function iterator():Iterator<T> {
-		return null; //TODO
+		return new ArrayIterator(arr);
 	}
 
 	public function join(sep:String):String {
@@ -68,7 +85,8 @@ class Array<T> {
 	}
 
 	public function lastIndexOf(x:T, ?fromIndex:Int):Int {
-		if (fromIndex == null) fromIndex = length;
+		if (fromIndex == null || fromIndex >= length) fromIndex = length - 1;
+		if (fromIndex < 0) fromIndex += length - 1;
 		while (fromIndex >= 0) {
 			if (arr[fromIndex] == x)
 				return fromIndex;
@@ -130,11 +148,29 @@ class Array<T> {
 		return "array"; //TODO
 	}
 
-	static function wrap<T>(arr:NativeArrayI<T>):Array<T> {
+	static function wrap<T>(arr:NativeIndexedArray<T>):Array<T> {
 		var a = new Array();
 		a.arr = arr;
 		a.length = arr.count();
 		return a;
 	}
 
+}
+
+private class ArrayIterator<T> {
+	var idx:Int;
+	var arr:NativeIndexedArray<T>;
+
+	public inline function new(arr:NativeIndexedArray<T>) {
+		arr = this.arr = arr;
+		idx = 0;
+	}
+
+	public inline function hasNext():Bool {
+		return idx < arr.count();
+	}
+
+	public inline function next():T {
+		return arr[idx++];
+	}
 }

--- a/std/php7/_std/Array.hx
+++ b/std/php7/_std/Array.hx
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C)2005-2016 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+import php7.NativeArray;
+
+@:coreApi
+@:native("HxArray")
+class Array<T> {
+	public var length(default, null):Int;
+	var arr:NativeArrayI<T>;
+
+	public function new() {
+		arr = new NativeArrayI<T>();
+		length = 0;
+	}
+
+	public function concat(a:Array<T>):Array<T> {
+		return wrap(arr.merge(a.arr));
+	}
+
+	public function copy():Array<T> {
+		return wrap(arr);
+	}
+
+	public function filter(f:T->Bool):Array<T> {
+		return wrap(arr.filter(f));
+	}
+
+	public function indexOf(x:T, ?fromIndex:Int):Int {
+		if (fromIndex == null) fromIndex = 0;
+		while (fromIndex < length) {
+			if (arr[fromIndex] == x)
+				return fromIndex;
+			fromIndex++;
+		}
+		return -1;
+	}
+
+	public function insert(pos:Int, x:T):Void {
+		length++;
+		arr.splice(pos, 0, x);
+	}
+
+	public function iterator():Iterator<T> {
+		return null; //TODO
+	}
+
+	public function join(sep:String):String {
+		return arr.implode(sep);
+	}
+
+	public function lastIndexOf(x:T, ?fromIndex:Int):Int {
+		if (fromIndex == null) fromIndex = length;
+		while (fromIndex >= 0) {
+			if (arr[fromIndex] == x)
+				return fromIndex;
+			fromIndex--;
+		}
+		return -1;
+	}
+
+	public function map<S>(f:T->S):Array<S> {
+		return wrap(arr.map(f));
+	}
+
+	public function pop():Null<T> {
+		if (length > 0) length--;
+		return arr.pop();
+	}
+
+	public function push(x:T):Int {
+		return length = arr.push(x);
+	}
+
+	public function remove(x:T):Bool {
+		for (i in 0...length) {
+			if (arr[i] == x) {
+				arr.splice(i, 1);
+				length--;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function reverse():Void {
+		arr = arr.reverse();
+	}
+
+	public function shift():Null<T> {
+		if (length > 0) length--;
+		return arr.shift();
+	}
+
+	public function slice(pos:Int, ?end:Int):Array<T> {
+		return wrap(arr.slice(pos, end == null ? null : end - pos));
+	}
+
+	public function sort(f:T->T->Int):Void {
+		arr.usort(f);
+	}
+
+	public function splice(pos:Int, len:Int):Array<T> {
+		return wrap(arr.splice(pos, len));
+	}
+
+	public function unshift(x:T):Void {
+		length = arr.unshift(x);
+	}
+
+	public function toString():String {
+		return "array"; //TODO
+	}
+
+	static function wrap<T>(arr:NativeArrayI<T>):Array<T> {
+		var a = new Array();
+		a.arr = arr;
+		a.length = arr.count();
+		return a;
+	}
+
+}

--- a/std/php7/_std/Reflect.hx
+++ b/std/php7/_std/Reflect.hx
@@ -36,7 +36,7 @@
 	public static function getProperty( o : Dynamic, field : String ) : Dynamic {
 		if (null == o) return null;
 		var cls : String = Std.is(o, Class) ? untyped __php__("$o->__tname__") : untyped __call__("get_class", o);
-		var cls_vars : php7.NativeArray = untyped __call__("get_class_vars", cls);
+		var cls_vars = untyped __call__("get_class_vars", cls);
 		if (untyped __php__("isset($cls_vars['__properties__']) && isset($cls_vars['__properties__']['get_'.$field]) && ($field = $cls_vars['__properties__']['get_'.$field])"))
 			return untyped __php__("$o->$field()");
 		else
@@ -46,7 +46,7 @@
 	public static function setProperty( o : Dynamic, field : String, value : Dynamic ) : Void {
 		if (null == o) return null;
 		var cls : String = Std.is(o, Class) ? untyped __php__("$o->__tname__") : untyped __call__("get_class", o);
-		var cls_vars : php7.NativeArray = untyped __call__("get_class_vars", cls);
+		var cls_vars  = untyped __call__("get_class_vars", cls);
 		if (untyped __php__("isset($cls_vars['__properties__']) && isset($cls_vars['__properties__']['set_'.$field]) && ($field = $cls_vars['__properties__']['set_'.$field])"))
 			untyped __php__("$o->$field($value)");
 		else


### PR DESCRIPTION
Here's a basic Array implementation with NativeArray as an abstract and NativeArrayI as an abstract for an indexed array. Not complete, just some code I had lying around from earlier experiments.
Note that `@:coreType NativeArray<T>` causes the compiler to hang. There seems to be something wrong with handling abstracts without underlying type (`@coreType`).
