### PR TITLE
Additions to #44

### DIFF
--- a/src/generators/genphp7.ml
+++ b/src/generators/genphp7.ml
@@ -31,7 +31,7 @@ let haxe_exception_path = (["php7"], "HException")
 (**
 	Type path of `php7.Boot`
 *)
-let boot_class_path = (["php7"], "Boot")
+let boot_type_path = (["php7"], "Boot")
 (**
 	Type path of the base class for all enums: `php7.Boot.HxEnum`
 *)
@@ -926,11 +926,11 @@ class virtual type_builder ctx wrapper =
 			match exprs with
 				| [] -> self#write ("new " ^ (self#use array_type_path) ^ "()")
 				| [expr] ->
-					self#write ((self#use boot_class_path) ^ "::array([");
+					self#write ((self#use array_type_path) ^ "::wrap([");
 					self#write_expr expr;
 					self#write "])"
 				| _ ->
-					self#write ((self#use boot_class_path) ^ "::array([\n");
+					self#write ((self#use array_type_path) ^ "::wrap([\n");
 					self#indent_more;
 					List.iter (fun expr -> self#write_array_item expr) exprs;
 					self#indent_less;
@@ -1195,13 +1195,13 @@ class virtual type_builder ctx wrapper =
 				| _ :: { eexpr = TField _ } :: _ -> self#write (self#use type_path)
 				| _ ->
 					let type_name = get_full_type_name ~escape:true type_path in
-					self#write ((self#use boot_class_path) ^ "::getClass('" ^ type_name ^ "')")
+					self#write ((self#use boot_type_path) ^ "::getClass('" ^ type_name ^ "')")
 		(**
 			Writes binary operation to output buffer
 		*)
 		method private write_expr_binop operation expr1 expr2 =
 			let write_shiftRightUnsigned () =
-				self#write ((self#use boot_class_path) ^ "::shiftRightUnsigned(");
+				self#write ((self#use boot_type_path) ^ "::shiftRightUnsigned(");
 				self#write_expr expr1;
 				self#write ", ";
 				self#write_expr expr2;
@@ -1655,7 +1655,7 @@ class class_builder ctx (cls:tclass) =
 						at_least_one_field_written := true;
 						self#write_field is_static field
 			in
-			if boot_class_path = self#get_type_path then begin
+			if boot_type_path = self#get_type_path then begin
 				self#write_php_prefix ();
 				at_least_one_field_written := true
 			end;

--- a/std/php7/ArrayAccess.hx
+++ b/std/php7/ArrayAccess.hx
@@ -1,0 +1,13 @@
+package php7;
+
+/**
+	Native PHP interface.
+	@see http://php.net/manual/en/class.arrayaccess.php
+**/
+@:native('ArrayAccess')
+extern interface ArrayAccess<K,V> {
+	function offsetExists( offset:K ) : Bool;
+	function offsetGet( offset:K ) : V;
+	function offsetSet( offset:K, value:V ) : Void;
+	function offsetUnset( offset:K ) : Void;
+}

--- a/std/php7/Boot.hx
+++ b/std/php7/Boot.hx
@@ -61,13 +61,6 @@ class Boot {
 	}
 
 	/**
-		Builds Haxe Array from array declaration syntax.
-	**/
-	public static function array( arr:NativeIndexedArray<Dynamic> ) : Array<Dynamic> {
-		return @:privateAccess Array.wrap(arr);
-	}
-
-	/**
 		`Std.is()` implementation
 	**/
 	public static function is( value:Dynamic, type:Class<Dynamic> ) : Bool {

--- a/std/php7/Boot.hx
+++ b/std/php7/Boot.hx
@@ -61,6 +61,13 @@ class Boot {
 	}
 
 	/**
+		Builds Haxe Array from array declaration syntax.
+	**/
+	public static function array( arr:NativeIndexedArray<Dynamic> ) : Array<Dynamic> {
+		return @:privateAccess Array.wrap(arr);
+	}
+
+	/**
 		`Std.is()` implementation
 	**/
 	public static function is( value:Dynamic, type:Class<Dynamic> ) : Bool {

--- a/std/php7/Const.hx
+++ b/std/php7/Const.hx
@@ -1,28 +1,33 @@
 package php7;
 
 /**
-    This class contains externs for native PHP constants defined in global namespace.
-    For native PHP functions in global namespace see `php7.Global`.
+	This class contains externs for native PHP constants defined in global namespace.
+	For native PHP functions in global namespace see `php7.Global`.
 **/
 @:phpGlobal
 extern class Const {
-    /**
-        @see http://php.net/manual/en/errorfunc.constants.php
-    **/
-    static var E_ERROR : Int;
-    static var E_WARNING : Int;
-    static var E_PARSE : Int;
-    static var E_NOTICE : Int;
-    static var E_CORE_ERROR : Int;
-    static var E_CORE_WARNING : Int;
-    static var E_COMPILE_ERROR : Int;
-    static var E_COMPILE_WARNING : Int;
-    static var E_USER_ERROR : Int;
-    static var E_USER_WARNING : Int;
-    static var E_USER_NOTICE : Int;
-    static var E_STRICT : Int;
-    static var E_RECOVERABLE_ERROR : Int;
-    static var E_DEPRECATED : Int;
-    static var E_USER_DEPRECATED : Int;
-    static var E_ALL : Int;
+	/**
+		@see http://php.net/manual/en/errorfunc.constants.php
+	**/
+	static var E_ERROR : Int;
+	static var E_WARNING : Int;
+	static var E_PARSE : Int;
+	static var E_NOTICE : Int;
+	static var E_CORE_ERROR : Int;
+	static var E_CORE_WARNING : Int;
+	static var E_COMPILE_ERROR : Int;
+	static var E_COMPILE_WARNING : Int;
+	static var E_USER_ERROR : Int;
+	static var E_USER_WARNING : Int;
+	static var E_USER_NOTICE : Int;
+	static var E_STRICT : Int;
+	static var E_RECOVERABLE_ERROR : Int;
+	static var E_DEPRECATED : Int;
+	static var E_USER_DEPRECATED : Int;
+	static var E_ALL : Int;
+	/**
+		@see http://php.net/manual/en/function.count.php
+	**/
+	static var COUNT_NORMAL : Int;
+	static var COUNT_RECURSIVE : Int;
 }

--- a/std/php7/Const.hx
+++ b/std/php7/Const.hx
@@ -30,4 +30,9 @@ extern class Const {
 	**/
 	static var COUNT_NORMAL : Int;
 	static var COUNT_RECURSIVE : Int;
+	/**
+		@see http://php.net/manual/en/function.array-filter.php
+	**/
+	static var ARRAY_FILTER_USE_KEY : Int;
+	static var ARRAY_FILTER_USE_BOTH : Int;
 }

--- a/std/php7/Global.hx
+++ b/std/php7/Global.hx
@@ -1,6 +1,6 @@
 package php7;
 
-
+import haxe.extern.Rest;
 
 /**
 	This class contains externs for native PHP functions defined in global namespace.
@@ -78,8 +78,88 @@ extern class Global {
 	static function phpversion( extension:String ) : String ;
 
 	/**
-		@see http://php.net/manual/en/function.class_alias.php
+			@see http://php.net/manual/en/function.class_alias.php
 	**/
 	@:overload(function(original:String,alias:String):Bool {})
 	static function class_alias( original:String, alias:String, autoload:Bool ) : Bool ;
+
+
+	/**
+			@see http://php.net/manual/en/function.count.php
+	**/
+	@:overload(function(array:NativeArray):Int {})
+	static function count( array:NativeArray, mode:Int ) : Int ;
+
+	/**
+			@see http://php.net/manual/en/function.array-filter.php
+	**/
+	@:overload(function(array:NativeArray):NativeArray {})
+	@:overload(function(array:NativeArray,callback:Dynamic->Bool):NativeArray {})
+	static function array_filter( array:NativeArray, callback:Dynamic->Bool, flag:Int ) : NativeArray ;
+
+	/**
+			@see http://php.net/manual/en/function.implode.php
+	**/
+	static function implode( glue:String = "", array:NativeArray ) : String ;
+
+	/**
+			@see http://php.net/manual/en/function.array-map.php
+	**/
+	static function array_map( callback:Dynamic->Dynamic, array:Rest<NativeArray> ) : NativeArray ;
+
+	/**
+			@see http://php.net/manual/en/function.array-merge.php
+	**/
+	static function array_merge( array:Rest<NativeArray> ) : NativeArray ;
+
+	/**
+			@see http://php.net/manual/en/function.array-pop.php
+	**/
+	static function array_pop( array:NativeArray ) : Dynamic;
+
+	/**
+			@see http://php.net/manual/en/function.array-push.php
+	**/
+	static function array_push( array:NativeArray, value:Rest<Dynamic> ) : Int ;
+
+	/**
+			@see http://php.net/manual/en/function.array-reverse.php
+	**/
+	@:overload(function(array:NativeArray):NativeArray {})
+	static function array_reverse( array:NativeArray, preserve_keys:Bool ) : NativeArray ;
+
+	/**
+			@see http://php.net/manual/en/function.array-search.php
+	**/
+	@:overload(function(needle:Dynamic,haystack:NativeArray):Dynamic {})
+	static function array_search( needle:Dynamic, haystack:NativeArray, strict:Bool ) : Dynamic ;
+
+	/**
+			@see http://php.net/manual/en/function.array-shift.php
+	**/
+	static function array_shift( array:NativeArray ) : Dynamic ;
+
+	/**
+			@see http://php.net/manual/en/function.array-slice.php
+	**/
+	@:overload(function(array:NativeArray,offset:Int):NativeArray {})
+	@:overload(function(array:NativeArray,offset:Int,length:Int):NativeArray {})
+	static function array_slice( array:NativeArray, offset:Int, length:Int, preserve_keys:Bool ) : NativeArray ;
+
+	/**
+			@see http://php.net/manual/en/function.array-splice.php
+	**/
+	@:overload(function(array:NativeArray,offset:Int):NativeArray {})
+	@:overload(function(array:NativeArray,offset:Int,length:Int):NativeArray {})
+	static function array_splice( array:NativeArray, offset:Int, lenght:Int, replacement:Dynamic ) : NativeArray ;
+
+	/**
+			@see http://php.net/manual/en/function.array-unshift.php
+	**/
+	static function array_unshift( arr:NativeArray, value:Rest<Dynamic> ) : Int ;
+
+	/**
+			@see http://php.net/manual/en/function.usort.php
+	**/
+	static function usort( array:NativeArray, value_compare_func:Dynamic->Dynamic->Int ) : Bool ;
 }

--- a/std/php7/Global.hx
+++ b/std/php7/Global.hx
@@ -95,7 +95,7 @@ extern class Global {
 	**/
 	@:overload(function(array:NativeArray):NativeArray {})
 	@:overload(function(array:NativeArray,callback:Dynamic->Bool):NativeArray {})
-	static function array_filter( array:NativeArray, callback:Dynamic->Bool, flag:Int ) : NativeArray ;
+	static function array_filter( array:NativeArray, callback:Dynamic->?Dynamic->Bool, flag:Int ) : NativeArray ;
 
 	/**
 		@see http://php.net/manual/en/function.implode.php

--- a/std/php7/Global.hx
+++ b/std/php7/Global.hx
@@ -132,7 +132,7 @@ extern class Global {
 		@see http://php.net/manual/en/function.array-search.php
 	**/
 	@:overload(function(needle:Dynamic,haystack:NativeArray):Null<EitherType<String,Int>> {})
-	static function array_search( needle:Dynamic, haystack:NativeArray, strict:Bool ) : Null<EitherType<String,Int>> ;
+	static function array_search( needle:Dynamic, haystack:NativeArray, strict:Bool ) : EitherType<Bool,EitherType<String,Int>> ;
 
 	/**
 		@see http://php.net/manual/en/function.array-shift.php

--- a/std/php7/Global.hx
+++ b/std/php7/Global.hx
@@ -1,5 +1,6 @@
 package php7;
 
+import haxe.extern.EitherType;
 import haxe.extern.Rest;
 
 /**
@@ -78,88 +79,137 @@ extern class Global {
 	static function phpversion( extension:String ) : String ;
 
 	/**
-			@see http://php.net/manual/en/function.class_alias.php
+		@see http://php.net/manual/en/function.class_alias.php
 	**/
 	@:overload(function(original:String,alias:String):Bool {})
 	static function class_alias( original:String, alias:String, autoload:Bool ) : Bool ;
 
-
 	/**
-			@see http://php.net/manual/en/function.count.php
+		@see http://php.net/manual/en/function.count.php
 	**/
 	@:overload(function(array:NativeArray):Int {})
 	static function count( array:NativeArray, mode:Int ) : Int ;
 
 	/**
-			@see http://php.net/manual/en/function.array-filter.php
+		@see http://php.net/manual/en/function.array-filter.php
 	**/
 	@:overload(function(array:NativeArray):NativeArray {})
 	@:overload(function(array:NativeArray,callback:Dynamic->Bool):NativeArray {})
 	static function array_filter( array:NativeArray, callback:Dynamic->Bool, flag:Int ) : NativeArray ;
 
 	/**
-			@see http://php.net/manual/en/function.implode.php
+		@see http://php.net/manual/en/function.implode.php
 	**/
 	static function implode( glue:String = "", array:NativeArray ) : String ;
 
 	/**
-			@see http://php.net/manual/en/function.array-map.php
+		@see http://php.net/manual/en/function.array-map.php
 	**/
 	static function array_map( callback:Dynamic->Dynamic, array:Rest<NativeArray> ) : NativeArray ;
 
 	/**
-			@see http://php.net/manual/en/function.array-merge.php
+		@see http://php.net/manual/en/function.array-merge.php
 	**/
 	static function array_merge( array:Rest<NativeArray> ) : NativeArray ;
 
 	/**
-			@see http://php.net/manual/en/function.array-pop.php
+		@see http://php.net/manual/en/function.array-pop.php
 	**/
 	static function array_pop( array:NativeArray ) : Dynamic;
 
 	/**
-			@see http://php.net/manual/en/function.array-push.php
+		@see http://php.net/manual/en/function.array-push.php
 	**/
 	static function array_push( array:NativeArray, value:Rest<Dynamic> ) : Int ;
 
 	/**
-			@see http://php.net/manual/en/function.array-reverse.php
+		@see http://php.net/manual/en/function.array-reverse.php
 	**/
 	@:overload(function(array:NativeArray):NativeArray {})
 	static function array_reverse( array:NativeArray, preserve_keys:Bool ) : NativeArray ;
 
 	/**
-			@see http://php.net/manual/en/function.array-search.php
+		@see http://php.net/manual/en/function.array-search.php
 	**/
-	@:overload(function(needle:Dynamic,haystack:NativeArray):Dynamic {})
-	static function array_search( needle:Dynamic, haystack:NativeArray, strict:Bool ) : Dynamic ;
+	@:overload(function(needle:Dynamic,haystack:NativeArray):Null<EitherType<String,Int>> {})
+	static function array_search( needle:Dynamic, haystack:NativeArray, strict:Bool ) : Null<EitherType<String,Int>> ;
 
 	/**
-			@see http://php.net/manual/en/function.array-shift.php
+		@see http://php.net/manual/en/function.array-shift.php
 	**/
 	static function array_shift( array:NativeArray ) : Dynamic ;
 
 	/**
-			@see http://php.net/manual/en/function.array-slice.php
+		@see http://php.net/manual/en/function.array-slice.php
 	**/
 	@:overload(function(array:NativeArray,offset:Int):NativeArray {})
 	@:overload(function(array:NativeArray,offset:Int,length:Int):NativeArray {})
 	static function array_slice( array:NativeArray, offset:Int, length:Int, preserve_keys:Bool ) : NativeArray ;
 
 	/**
-			@see http://php.net/manual/en/function.array-splice.php
+		@see http://php.net/manual/en/function.array-splice.php
 	**/
 	@:overload(function(array:NativeArray,offset:Int):NativeArray {})
 	@:overload(function(array:NativeArray,offset:Int,length:Int):NativeArray {})
 	static function array_splice( array:NativeArray, offset:Int, lenght:Int, replacement:Dynamic ) : NativeArray ;
 
 	/**
-			@see http://php.net/manual/en/function.array-unshift.php
+		@see http://php.net/manual/en/function.array-unshift.php
 	**/
 	static function array_unshift( arr:NativeArray, value:Rest<Dynamic> ) : Int ;
 
 	/**
-			@see http://php.net/manual/en/function.usort.php
+		@see http://php.net/manual/en/function.array-values.php
+	**/
+	static function array_values( arr:NativeArray ) : NativeIndexedArray<Dynamic> ;
+
+	/**
+		@see http://php.net/manual/en/function.array-keys.php
+	**/
+	static function array_keys( arr:NativeArray ) : NativeIndexedArray<EitherType<String,Int>> ;
+
+	/**
+		@see http://php.net/manual/en/function.array-fill.php
+	**/
+	static function array_fill( start_index:Int, num:Int, value:Dynamic ) : NativeArray ;
+
+	/**
+		@see http://php.net/manual/en/function.usort.php
 	**/
 	static function usort( array:NativeArray, value_compare_func:Dynamic->Dynamic->Int ) : Bool ;
+
+	/**
+		@see http://php.net/manual/en/function.reset.php
+	**/
+	static function reset( array:NativeArray ) : Dynamic;
+
+	/**
+		@see http://php.net/manual/en/function.current.php
+	**/
+	static function current( array:NativeArray ) : Dynamic;
+
+	/**
+		@see http://php.net/manual/en/function.next.php
+	**/
+	static function next( array:NativeArray ) : Dynamic;
+
+	/**
+		@see http://php.net/manual/en/function.prev.php
+	**/
+	static function prev( array:NativeArray ) : Dynamic;
+
+	/**
+		@see http://php.net/manual/en/function.end.php
+	**/
+	static function end( array:NativeArray ) : Dynamic;
+
+	/**
+		@see http://php.net/manual/en/function.key.php
+	**/
+	static function key( array:NativeArray ) : EitherType<String,Int>;
+
+	/**
+		@see http://php.net/manual/en/function.each.php
+	**/
+	static function each( array:NativeArray ) : NativeArray;
 }

--- a/std/php7/Lib.hx
+++ b/std/php7/Lib.hx
@@ -85,12 +85,12 @@ class Lib {
 		return untyped __call__("fpassthru", __call__("fopen", file,  "r"));
 	}
 
-	public static function toPhpArray(a : Array<Dynamic>) : NativeArray {
-		throw "Not implemented";
+	public static inline function toPhpArray(a : Array<Dynamic>) : NativeArray {
+		return @:privateAccess a.arr;
 	}
 
 	public static inline function toHaxeArray(a : NativeArray) : Array<Dynamic> {
-		throw "Not implemented";
+		return @:privateAccess Array.wrap(a);
 	}
 
 	public static function hashOfAssociativeArray<T>(arr : NativeArray) : Map<String,T> {

--- a/std/php7/NativeArray.hx
+++ b/std/php7/NativeArray.hx
@@ -36,29 +36,6 @@ using php7.Global;
 	@:arrayAccess function get(key:Scalar):Dynamic;
 	@:arrayAccess function set(key:Scalar, val:Dynamic):Dynamic;
 
-	public inline function keys():NativeIndexedArray<EitherType<String,Int>>
-		return Global.array_keys(this);
-
-	public inline function values():NativeIndexedArray<Dynamic>
-		return Global.array_values(this);
-
-	public inline function count():Int
-		return Global.count(this);
-
-	public inline function implode(glue:String):String
-		return Global.implode(glue, this);
-
-	public inline function merge(arr:NativeArray):NativeArray
-		return Global.array_merge(this, arr);
-
-	// Not sure if these methods should be added, because PHP `slice` and `reverse` differ from Haxe analogues.
-	// These methods are potential source of mistakes and confusions for end-users.
-	//
-	// public inline function slice(offset:Int, len:Int):NativeArray
-	// 	return Global.array_slice(this, offset, len);
-	// public inline function reverse():NativeArray
-	// 	return Global.array_reverse(this);
-
 	public inline function iterator()
 		return new NativeArrayIterator(this);
 }

--- a/std/php7/NativeAssocArray.hx
+++ b/std/php7/NativeAssocArray.hx
@@ -31,7 +31,10 @@ abstract NativeAssocArray<T>(NativeArray) from NativeArray to NativeArray {
 		return this[key];
 
 	@:arrayAccess
-	inline function set(key:String, val:T)
-		this[key] = val;
+	inline function set(key:String, val:T):T
+		return this[key] = val;
 
+    //TODO
+    // @:to function toMap():Map<String,T>
+    // @:from static function fromMap<T>(map:Map<String,T>):NativeAssocArray<T>
 }

--- a/std/php7/NativeAssocArray.hx
+++ b/std/php7/NativeAssocArray.hx
@@ -21,37 +21,17 @@
  */
 package php7;
 
-import haxe.extern.EitherType;
-
-//@:coreType //doesn't seem to work atm
-//@:arrayAccess
-@:runtimeValue
-abstract NativeArray(Dynamic) {
+@:forward
+abstract NativeAssocArray<T>(NativeArray) from NativeArray to NativeArray {
 	public inline function new()
 		this = untyped __php__("[]");
 
 	@:arrayAccess
-	inline function get(key:Scalar):Dynamic
+	inline function get(key:String):T
 		return this[key];
 
 	@:arrayAccess
-	inline function set(key:Scalar, val:Dynamic)
+	inline function set(key:String, val:T)
 		this[key] = val;
 
-	public inline function count():Int
-		return Global.count(this);
-
-	public inline function implode(glue:String):String
-		return Global.implode(glue, this);
-
-	public inline function merge(arr:NativeArray):NativeArray
-		return Global.array_merge(this, arr);
-
-	public inline function reverse():NativeArray
-		return Global.array_reverse(this);
-
-	public inline function slice(offset:Int, len:Int):NativeArray
-		return Global.array_slice(this, offset, len);
 }
-
-private typedef Scalar = EitherType<Int,EitherType<String,EitherType<Float,Bool>>>;

--- a/std/php7/NativeIndexedArray.hx
+++ b/std/php7/NativeIndexedArray.hx
@@ -43,31 +43,4 @@ abstract NativeIndexedArray<T>(NativeArray) from NativeArray to NativeArray {
 	@:from
 	static inline function fromHaxeArray<T>(a:Array<T>):NativeIndexedArray<T>
 		return @:privateAccess a.arr;
-
-	public inline function filter(cb:T->Bool):NativeIndexedArray<T>
-		return Global.array_filter(this, cb);
-
-	public inline function map<S>(cb:T->S):NativeIndexedArray<S>
-		return Global.array_map(cb, this);
-
-	public inline function pop():T
-		return Global.array_pop(this);
-
-	public inline function push(val:T):Int
-		return Global.array_push(this, val);
-
-	public inline function search(needle:T):Null<EitherType<String,Int>>
-		return Global.array_search(needle, this, true);
-
-	public inline function shift():T
-		return Global.array_shift(this);
-
-	public inline function splice(offset:Int, len:Int, ?repl:T):NativeIndexedArray<T>
-		return Global.array_splice(this, offset, len, repl);
-
-	public inline function unshift(val:T):Int
-		return Global.array_unshift(this, val);
-
-	public inline function usort(func:T->T->Int):Bool
-		return Global.usort(this, func);
 }

--- a/std/php7/NativeIndexedArray.hx
+++ b/std/php7/NativeIndexedArray.hx
@@ -33,8 +33,8 @@ abstract NativeIndexedArray<T>(NativeArray) from NativeArray to NativeArray {
 		return this[idx];
 
 	@:arrayAccess
-	inline function set(idx:Int, val:T)
-		this[idx] = val;
+	inline function set(idx:Int, val:T):T
+		return this[idx] = val;
 
 	@:to
 	inline function toHaxeArray():Array<T>
@@ -56,7 +56,7 @@ abstract NativeIndexedArray<T>(NativeArray) from NativeArray to NativeArray {
 	public inline function push(val:T):Int
 		return Global.array_push(this, val);
 
-	public inline function search(needle:T):KeyOrFalse
+	public inline function search(needle:T):Null<EitherType<String,Int>>
 		return Global.array_search(needle, this, true);
 
 	public inline function shift():T
@@ -71,5 +71,3 @@ abstract NativeIndexedArray<T>(NativeArray) from NativeArray to NativeArray {
 	public inline function usort(func:T->T->Int):Bool
 		return Global.usort(this, func);
 }
-
-private typedef KeyOrFalse = EitherType<EitherType<String,Int>,Bool>;

--- a/std/php7/NativeIndexedArray.hx
+++ b/std/php7/NativeIndexedArray.hx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C)2005-2016 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package php7;
+
+import haxe.extern.EitherType;
+
+@:forward
+abstract NativeIndexedArray<T>(NativeArray) from NativeArray to NativeArray {
+	public inline function new()
+		this = untyped __php__("[]");
+
+	@:arrayAccess
+	inline function get(idx:Int):T
+		return this[idx];
+
+	@:arrayAccess
+	inline function set(idx:Int, val:T)
+		this[idx] = val;
+
+	@:to
+	inline function toHaxeArray():Array<T>
+		return @:privateAccess Array.wrap(this);
+
+	@:from
+	static inline function fromHaxeArray<T>(a:Array<T>):NativeIndexedArray<T>
+		return @:privateAccess a.arr;
+
+	public inline function filter(cb:T->Bool):NativeIndexedArray<T>
+		return Global.array_filter(this, cb);
+
+	public inline function map<S>(cb:T->S):NativeIndexedArray<S>
+		return Global.array_map(cb, this);
+
+	public inline function pop():T
+		return Global.array_pop(this);
+
+	public inline function push(val:T):Int
+		return Global.array_push(this, val);
+
+	public inline function search(needle:T):KeyOrFalse
+		return Global.array_search(needle, this, true);
+
+	public inline function shift():T
+		return Global.array_shift(this);
+
+	public inline function splice(offset:Int, len:Int, ?repl:T):NativeIndexedArray<T>
+		return Global.array_splice(this, offset, len, repl);
+
+	public inline function unshift(val:T):Int
+		return Global.array_unshift(this, val);
+
+	public inline function usort(func:T->T->Int):Bool
+		return Global.usort(this, func);
+}
+
+private typedef KeyOrFalse = EitherType<EitherType<String,Int>,Bool>;

--- a/std/php7/Scalar.hx
+++ b/std/php7/Scalar.hx
@@ -1,0 +1,9 @@
+package php7;
+
+import haxe.extern.EitherType;
+
+
+/**
+    `Scalar` is a type that is compatible with any scalar value (int, float, bool, string)
+**/
+typedef Scalar = EitherType<Int, EitherType<String, EitherType<Float, Bool>>>;

--- a/std/php7/_std/Array.hx
+++ b/std/php7/_std/Array.hx
@@ -36,7 +36,7 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 	}
 
 	public inline function concat(a:Array<T>):Array<T> {
-		return wrap(arr.merge(a.arr));
+		return wrap(Global.array_merge(arr, a.arr));
 	}
 
 	public inline function copy():Array<T> {
@@ -44,7 +44,7 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 	}
 
 	public inline function filter(f:T->Bool):Array<T> {
-		return wrap(arr.filter(f));
+		return wrap(Global.array_filter(arr, f));
 	}
 
 	public function indexOf(x:T, ?fromIndex:Int):Int {
@@ -68,7 +68,7 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 
 	public inline function insert(pos:Int, x:T):Void {
 		length++;
-		arr.splice(pos, 0, x);
+		Global.array_splice(arr, pos, 0, x);
 	}
 
 	public inline function iterator() : ArrayIterator<T> {
@@ -76,7 +76,7 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 	}
 
 	public inline function join(sep:String):String {
-		return arr.implode(sep);
+		return Global.implode(sep, arr);
 	}
 
 	public function lastIndexOf(x:T, ?fromIndex:Int):Int {
@@ -91,22 +91,22 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 	}
 
 	public inline function map<S>(f:T->S):Array<S> {
-		return wrap(arr.map(f));
+		return wrap(Global.array_map(f, arr));
 	}
 
 	public function pop():Null<T> {
 		if (length > 0) length--;
-		return arr.pop();
+		return Global.array_pop(arr);
 	}
 
 	public inline function push(x:T):Int {
-		return length = arr.push(x);
+		return length = Global.array_push(arr, x);
 	}
 
 	public function remove(x:T):Bool {
 		for (i in 0...length) {
 			if (arr[i] == x) {
-				arr.splice(i, 1);
+				Global.array_splice(arr, i, 1);
 				length--;
 				return true;
 			}
@@ -120,7 +120,7 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 
 	public function shift():Null<T> {
 		if (length > 0) length--;
-		return arr.shift();
+		return Global.array_shift(arr);
 	}
 
 	public function slice(pos:Int, ?end:Int):Array<T> {
@@ -143,11 +143,11 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 	}
 
 	public inline function splice(pos:Int, len:Int):Array<T> {
-		return wrap(arr.splice(pos, len));
+		return wrap(Global.array_splice(arr, pos, len));
 	}
 
 	public inline function unshift(x:T):Void {
-		length = arr.unshift(x);
+		length = Global.array_unshift(arr, x);
 	}
 
 	public function toString():String {
@@ -167,7 +167,7 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 	@:noCompletion
 	public function offsetSet( offset:Int, value:T ) : Void {
 		if (length <= offset) {
-			arr = arr.merge(Global.array_fill(0, offset + 1 - length, null));
+			arr = Global.array_merge(arr, Global.array_fill(0, offset + 1 - length, null));
 		}
 		arr[offset] = value;
 	}
@@ -175,7 +175,7 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 	@:noCompletion
 	public function offsetUnset( offset:Int ) : Void {
 		if (offset >= 0 && offset < length ) {
-			arr.splice(offset, 1);
+			Global.array_splice(arr, offset, 1);
 			length--;
 		}
 	}
@@ -183,7 +183,7 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 	static function wrap<T>(arr:NativeIndexedArray<T>):Array<T> {
 		var a = new Array();
 		a.arr = arr;
-		a.length = arr.count();
+		a.length = Global.count(arr);
 		return a;
 	}
 }

--- a/std/php7/_std/Array.hx
+++ b/std/php7/_std/Array.hx
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C)2005-2016 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+import php7.NativeIndexedArray;
+
+@:coreApi
+@:native("HxArray")
+class Array<T> {
+	public var length(default, null):Int;
+	var arr:NativeIndexedArray<T>;
+
+	public function new() {
+		arr = new NativeIndexedArray<T>();
+		length = 0;
+	}
+
+	public function concat(a:Array<T>):Array<T> {
+		return wrap(arr.merge(a.arr));
+	}
+
+	public function copy():Array<T> {
+		return wrap(arr);
+	}
+
+	public function filter(f:T->Bool):Array<T> {
+		return wrap(arr.filter(f));
+	}
+
+	public function indexOf(x:T, ?fromIndex:Int):Int {
+		/*if (fromIndex == null) fromIndex = 0;
+		if (fromIndex < 0) fromIndex += length - 1;
+		if (fromIndex < 0) fromIndex = 0;
+		while (fromIndex < length) {
+			if (arr[fromIndex] == x)
+				return fromIndex;
+			fromIndex++;
+		}
+		return -1;*/
+		// maybe better?
+		var idx = arr.search(x);
+		if (idx == false)
+			return -1;
+		if (fromIndex != null) {
+			if (fromIndex >= length)
+				return -1;
+			if (fromIndex < 0) fromIndex += length - 1;
+			if (fromIndex > 0) {
+				idx -= fromIndex;
+				if ((idx:Int) < 0)
+					return -1;
+			}
+		}
+		return idx;
+	}
+
+	public function insert(pos:Int, x:T):Void {
+		length++;
+		arr.splice(pos, 0, x);
+	}
+
+	public function iterator():Iterator<T> {
+		return new ArrayIterator(arr);
+	}
+
+	public function join(sep:String):String {
+		return arr.implode(sep);
+	}
+
+	public function lastIndexOf(x:T, ?fromIndex:Int):Int {
+		if (fromIndex == null || fromIndex >= length) fromIndex = length - 1;
+		if (fromIndex < 0) fromIndex += length - 1;
+		while (fromIndex >= 0) {
+			if (arr[fromIndex] == x)
+				return fromIndex;
+			fromIndex--;
+		}
+		return -1;
+	}
+
+	public function map<S>(f:T->S):Array<S> {
+		return wrap(arr.map(f));
+	}
+
+	public function pop():Null<T> {
+		if (length > 0) length--;
+		return arr.pop();
+	}
+
+	public function push(x:T):Int {
+		return length = arr.push(x);
+	}
+
+	public function remove(x:T):Bool {
+		for (i in 0...length) {
+			if (arr[i] == x) {
+				arr.splice(i, 1);
+				length--;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function reverse():Void {
+		arr = arr.reverse();
+	}
+
+	public function shift():Null<T> {
+		if (length > 0) length--;
+		return arr.shift();
+	}
+
+	public function slice(pos:Int, ?end:Int):Array<T> {
+		return wrap(arr.slice(pos, end == null ? null : end - pos));
+	}
+
+	public function sort(f:T->T->Int):Void {
+		arr.usort(f);
+	}
+
+	public function splice(pos:Int, len:Int):Array<T> {
+		return wrap(arr.splice(pos, len));
+	}
+
+	public function unshift(x:T):Void {
+		length = arr.unshift(x);
+	}
+
+	public function toString():String {
+		return "array"; //TODO
+	}
+
+	static function wrap<T>(arr:NativeIndexedArray<T>):Array<T> {
+		var a = new Array();
+		a.arr = arr;
+		a.length = arr.count();
+		return a;
+	}
+
+}
+
+private class ArrayIterator<T> {
+	var idx:Int;
+	var arr:NativeIndexedArray<T>;
+
+	public inline function new(arr:NativeIndexedArray<T>) {
+		arr = this.arr = arr;
+		idx = 0;
+	}
+
+	public inline function hasNext():Bool {
+		return idx < arr.count();
+	}
+
+	public inline function next():T {
+		return arr[idx++];
+	}
+}

--- a/std/php7/_std/Array.hx
+++ b/std/php7/_std/Array.hx
@@ -48,7 +48,14 @@ class Array<T> implements php7.ArrayAccess<Int,T> {
 	}
 
 	public function indexOf(x:T, ?fromIndex:Int):Int {
-		if (fromIndex == null) fromIndex = 0;
+		if (fromIndex == null) {
+			var index = Global.array_search(x, arr, true);
+			if (index == false) {
+				return -1;
+			} else {
+				return index;
+			}
+		}
 		if (fromIndex < 0) fromIndex += length;
 		if (fromIndex < 0) fromIndex = 0;
 		while (fromIndex < length) {


### PR DESCRIPTION
Hey @mockey i've made some changes to your PR. And i'd like to discuss it.
Could you review it please and tell me what you think?

I've implemented inlining for array access for `Array<T>` in generator, so `a[2]` becomes `$a->arr[2]`.
But array access is inlined only for reading indexes [because of this](http://haxe.org/manual/std-Array.html):

> If a write access is made with a positive index which is out of bounds, null (or the default value for basic types on static targets) is inserted at all positions between the last defined index and the newly written one.

I had to add `ArrayAccess` interface to `Array` to handle writing values and situations like this:

``` haxe
var d : Dynamic = [1, 2, 3];
trace(d[2]); 
```

translated to

``` php
$d = Boot.array([1, 2, 3]);
Log.trace($d[2]); 
//Here compiler did not know that `a` is an `Array` so generator could not inline array access.
//But thanks to `ArrayAccess` interface everything `$d[2]` will work as expected.
```
